### PR TITLE
Update Icon of Misc Information in Contact

### DIFF
--- a/components/com_contact/tmpl/contact/default.php
+++ b/components/com_contact/tmpl/contact/default.php
@@ -171,7 +171,7 @@ $icon    = $this->params->get('contact_icons') == 0;
             <dl class="dl-horizontal">
                 <dt>
                     <?php if ($icon && !$this->params->get('marker_misc')) : ?>
-                        <span class="icon-home" aria-hidden="true"></span>
+                        <span class="icon-info-circle" aria-hidden="true"></span>
                     <?php elseif ($icon && $this->params->get('marker_misc')) : ?>
                         <span class="jicons-image">
                             <?php echo $this->params->get('marker_misc'); ?>


### PR DESCRIPTION
Until version 5.2 the icon for the Miscellaneous information is a black circle with the letter "i" in the middle (ie. icon-info-circle).

In version 5.3, the icon has changed to Home icon (ie. icon-home) which is same as that of the Website.

So, this change would differentiate the field identifications.

Pull Request for Issue # .

### Summary of Changes

Changed the icon of the Miscellaneous Information from icon-home to icon-infor-circle

### Testing Instructions

(a) Create a new contact with the miscellaneous information
(b) Create a menu item to display the contact created - make sure to choose Show for Misc Information
(c) Notice the Icon displayed for Misc Information

(d) Apply the code change

(e) Repeat step (c) and notice the icon change

### Actual result BEFORE applying this Pull Request

<img width="1710" height="1107" alt="Screenshot_Before_the_Icon_Change" src="https://github.com/user-attachments/assets/108139c6-3c4f-4686-8a72-67be70382118" />


### Expected result AFTER applying this Pull Request

<img width="1710" height="1107" alt="Screenshot_After_the_Icon_Change" src="https://github.com/user-attachments/assets/680e0fde-df33-4caf-91d3-823393bcaeb0" />


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
